### PR TITLE
Add Thai GitHub Pages guide for ChatGPT Codex

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,0 +1,85 @@
+---
+layout: default
+title: "แนะนำ ChatGPT Codex"
+---
+
+# แนะนำ ChatGPT Codex
+
+**อัปเดตล่าสุด:** 26 กันยายน 2025 เวลา 04:56 น. (UTC)
+
+ChatGPT Codex เป็นรุ่นหนึ่งของตระกูลโมเดล ChatGPT ที่ออกแบบมาสำหรับการทำความเข้าใจและสร้างโค้ดได้อย่างชาญฉลาด เหมาะสำหรับนักพัฒนาที่ต้องการตัวช่วยในการเขียนโค้ด อธิบายโค้ด หรือทำงาน DevOps รวมถึงผู้ที่ต้องการเรียนรู้การเขียนโปรแกรมผ่านการสนทนาภาษาไทยผสมศัพท์เทคนิคโดยตรง
+
+## ไฮไลต์ฟีเจอร์สำคัญ
+
+- **การเข้าใจหลายภาษาโปรแกรม:** รองรับภาษายอดนิยม เช่น Python, JavaScript, TypeScript, Go, Rust, C#, Java และอีกมากมาย
+- **บริบทเชิงลึก:** จดจำบริบทการสนทนาและโครงสร้างโปรเจ็กต์เพื่อเสนอคำตอบที่สอดคล้องกับไฟล์ที่กำลังแก้ไข
+- **การรีวิวโค้ดอัตโนมัติ:** วิเคราะห์ Pull Request, แนะนำการ refactor และตรวจหาข้อผิดพลาดที่อาจเกิดขึ้น
+- **การเขียนเทสและเอกสาร:** สร้าง unit test, integration test และเอกสารประกอบได้ในขั้นตอนเดียว
+- **Workflow เชื่อมต่อ GitHub:** สั่งให้เปิด branch, commit, push หรือสร้าง Pull Request ผ่านคำสั่งภาษาคนหรือ workflow อัตโนมัติ
+
+## การเตรียมใช้งาน (Setup)
+
+### 1. เตรียม API Access
+1. สมัครบัญชีที่ [https://platform.openai.com/](https://platform.openai.com/)
+2. สร้าง API key ที่หน้า **View API keys**
+3. เก็บ API key ในตัวแปรสภาพแวดล้อม เช่น `export OPENAI_API_KEY="sk-..."`
+
+### 2. ติดตั้ง CLI Toolkit (ตัวอย่าง: `openai` CLI)
+```bash
+pip install --upgrade openai
+openai --version
+```
+กำหนดค่าโปรไฟล์เริ่มต้น:
+```bash
+openai api keys add default --key "$OPENAI_API_KEY"
+```
+
+### 3. ติดตั้งปลั๊กอินใน IDE
+- **VS Code:** ค้นหา "ChatGPT Codex" หรือปลั๊กอินที่รองรับ OpenAI API ใน Marketplace > ติดตั้ง > ใส่ API key ในหน้าการตั้งค่า
+- **JetBrains IDEs:** ใช้ปลั๊กอิน "AI Assistant" หรือ "CodeGPT" แล้วกำหนด API endpoint ให้ใช้โมเดล `gpt-4.1-codex` หรือรุ่นที่ต้องการ
+
+### 4. เตรียมการเชื่อมต่อ GitHub
+1. สร้าง Personal Access Token ที่ [https://github.com/settings/tokens](https://github.com/settings/tokens)
+2. ตั้งค่าตัวแปร เช่น `export GITHUB_TOKEN="ghp_..."`
+3. ใช้คู่กับเครื่องมือ workflow (เช่น `gh` CLI หรือ automation script) เพื่อให้ ChatGPT Codex สามารถสั่งงานบน repository ได้
+
+## ตัวอย่างการใช้งาน
+
+### 1. การใช้งานผ่าน CLI
+```bash
+openai chat.completions.create \
+  --model gpt-4.1-codex \
+  --messages '[{"role":"system","content":"คุณคือผู้ช่วยโปรแกรมเมอร์"},{"role":"user","content":"ช่วยเขียนฟังก์ชัน merge sort ภาษา Python"}]' \
+  --temperature 0.3
+```
+คำตอบที่ได้จะเป็นโค้ดและคำอธิบาย สามารถ pipe ไปยังไฟล์หรือ CLI editor ได้ทันที
+
+### 2. การใช้งานผ่าน IDE
+1. เปิดไฟล์ที่ต้องการแก้ใน VS Code
+2. เลือกข้อความโค้ด > คลิกขวา > **Ask ChatGPT Codex**
+3. ป้อนคำสั่ง เช่น "อธิบายโค้ดส่วนนี้" หรือ "เพิ่ม unit test"
+4. ปลั๊กอินจะแทรกคำตอบกลับเข้าสู่ editor โดยอัตโนมัติ
+
+### 3. การรีวิวโค้ด (Code Review)
+- ผสาน ChatGPT Codex กับ workflow CI/CD (เช่น GitHub Actions)
+- ตั้งค่าให้เรียกใช้ endpoint `https://api.openai.com/v1/responses` พร้อมแนบ diff ของ Pull Request และคำสั่งรีวิว เช่น "แนะนำการปรับปรุงในรูปแบบ bullet"
+- โมเดลจะคืนข้อเสนอแนะเพื่อแนบเป็นคอมเมนต์อัตโนมัติหรือสรุปใน Summary Report
+
+### 4. การสั่งให้สร้างโค้ดจากหน้าเว็บที่เชื่อมต่อกับ GitHub
+1. ติดตั้ง web UI ที่รองรับการเชื่อมต่อ GitHub (เช่นแพลตฟอร์มภายในองค์กรหรือโครงการโอเพ่นซอร์สที่ใช้ OpenAI API)
+2. ลงชื่อเข้าใช้ด้วย GitHub OAuth เพื่อให้สิทธิ์เข้าถึง repository
+3. เปิดโปรเจ็กต์ > เลือก branch หรือสร้าง branch ใหม่
+4. ป้อนคำสั่ง เช่น "สร้าง service จัดการตะกร้าสินค้าในโฟลเดอร์ `src/cart`" จากนั้นระบบจะ
+   - ขอคำตอบจาก ChatGPT Codex
+   - สร้างไฟล์/โค้ดตามคำสั่ง
+   - เปิด Draft Pull Request ให้ตรวจสอบ
+5. ตรวจสอบ diff, แก้ไขเพิ่มเติม และกด Merge ผ่านหน้าเว็บได้ทันที
+
+## แนวทางการเรียนรู้เพิ่มเติม
+- [OpenAI Cookbook](https://github.com/openai/openai-cookbook) – ตัวอย่างโค้ดสำหรับการใช้งาน API
+- [เอกสาร OpenAI API (Responses API)](https://platform.openai.com/docs/guides/responses) – คู่มือการเรียกใช้งาน endpoint ล่าสุด
+- [GitHub Actions Docs](https://docs.github.com/actions) – สร้าง workflow อัตโนมัติให้ ChatGPT Codex เข้ามาช่วยรีวิวหรือดูแล deployment
+- [VS Code Marketplace](https://marketplace.visualstudio.com/vscode) – ค้นหาและอัปเดตปลั๊กอิน AI ช่วยเขียนโค้ด
+
+> เคล็ดลับ: ผสมภาษาไทยกับศัพท์เทคนิคตรงตัว (transliteration) ช่วยให้ ChatGPT Codex เข้าใจบริบทและเจตนาได้แม่นยำยิ่งขึ้น
+

--- a/index.md
+++ b/index.md
@@ -1,8 +1,3 @@
----
-layout: default
-title: "แนะนำ ChatGPT Codex"
----
-
 # แนะนำ ChatGPT Codex
 
 **อัปเดตล่าสุด:** 26 กันยายน 2025 เวลา 04:56 น. (UTC)


### PR DESCRIPTION
## Summary
- add a Thai-language GitHub Pages landing page introducing ChatGPT Codex
- document setup steps, usage scenarios (CLI, IDE, code review, web-to-GitHub), and learning resources

## Testing
- not run (documentation change only)


------
https://chatgpt.com/codex/tasks/task_e_68d61ca678388329a15c30bc71f16bc6